### PR TITLE
feat(cli): add CLI entry point for camera-segment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ classifiers = [
 license = "MIT"
 license-files = ["LICENSE"]
 
+[project.scripts]
+camera-segment = "camera_segment.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/jbussdieker/python-camera-segment"
 Documentation = "https://github.com/jbussdieker/python-camera-segment/blob/master/README.md"

--- a/src/camera_segment/__main__.py
+++ b/src/camera_segment/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+main()

--- a/src/camera_segment/cli.py
+++ b/src/camera_segment/cli.py
@@ -1,3 +1,11 @@
 from importlib.metadata import version
 
 __version__ = version("camera-segment")
+
+
+def main(sysv=None):
+    print(f"camera-segment: v{__version__}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,17 @@
 import unittest
+from io import StringIO
+from contextlib import redirect_stdout
 
-import camera_segment.cli
+from camera_segment.cli import main
 
 
 class TestCLI(unittest.TestCase):
-    def test_version(self):
-        self.assertIn("__version__", dir(camera_segment.cli))
+    def test_version_output(self):
+        buf = StringIO()
+        with redirect_stdout(buf):
+            main()
+        output = buf.getvalue()
+        self.assertIn("camera-segment: v", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Define `camera-segment` script in `pyproject.toml` for CLI access
- Implement `__main__.py` to allow module execution with `python -m`
- Update `cli.py` to include a `main` function that prints the version
- Add test for CLI version output using `unittest`