### PR TITLE
ci(workflow): fix checkout step to use release tag

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -85,6 +85,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
- Updates the checkout step to use the tag name from release-please outputs
- Ensures the correct code version is checked out during the workflow execution