### PR TITLE
ci(workflow): update permissions for release and deploy jobs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,11 +1,6 @@
 name: workflow
 on:
   push:
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  actions: write
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -71,6 +66,10 @@ jobs:
     outputs:
       release_created: ${{ steps.release-please.outputs.release_created }}
       tag_name: ${{ steps.release-please.outputs.tag_name }}
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: release-please
         id: release-please
@@ -82,6 +81,9 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created
     environment: pypi
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
- Remove global workflow permissions
- Add specific permissions for the release-please job: contents, issues, pull-requests
- Add specific permissions for the deploy job: contents, id-token