### PR TITLE
docs(pyproject): update URLs to use 'main' branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,10 @@ camera-segment = "camera_segment.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/jbussdieker/python-camera-segment"
-Documentation = "https://github.com/jbussdieker/python-camera-segment/blob/master/README.md"
+Documentation = "https://github.com/jbussdieker/python-camera-segment/blob/main/README.md"
 Repository = "https://github.com/jbussdieker/python-camera-segment"
 Issues = "https://github.com/jbussdieker/python-camera-segment/issues"
-Changelog = "https://github.com/jbussdieker/python-camera-segment/blob/master/CHANGELOG.md"
+Changelog = "https://github.com/jbussdieker/python-camera-segment/blob/main/CHANGELOG.md"
 
 [build-system]
 requires = ["setuptools", "setuptools-scm"]


### PR DESCRIPTION
- Change Documentation URL to point to the 'main' branch
- Update Changelog URL to reference the 'main' branch